### PR TITLE
Update check-reallocarray.sh to work with busybox mktemp

### DIFF
--- a/scripts/check-reallocarray.sh
+++ b/scripts/check-reallocarray.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Usage: check-reallocarray.sh cc_path [cc_args...]
 
-tfile=$(mktemp /tmp/test_reallocarray_XXXXXXXX.c)
+tfile=$(mktemp /tmp/test_reallocarray_XXXXXXXX).c
 ofile=${tfile%.c}.o
 
 cat > $tfile <<EOL


### PR DESCRIPTION
Busybox mktemp expect template to end with "XXXXXX". I made this small change so libbpf builds successfully on Alpine.